### PR TITLE
chore: simplify go package name

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -45,6 +45,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   publishToGo: {
     moduleName: 'github.com/cdklabs/awscdk-asset-kubectl-go',
+    packageName: `kubectlv${SPEC_VERSION}`,
     gitBranch: `kubectl.${SPEC_VERSION}`,
     gitUserName: 'AWS CDK Team',
     gitUserEmail: 'aws-cdk@amazon.com',

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
         "packageId": "Amazon.CDK.Asset.KubectlV20"
       },
       "go": {
-        "moduleName": "github.com/cdklabs/awscdk-asset-kubectl-go"
+        "moduleName": "github.com/cdklabs/awscdk-asset-kubectl-go",
+        "packageName": "kubectlv20"
       }
     },
     "tsc": {


### PR DESCRIPTION
By default, the package name seems to be `awscdkassetkubectlv20`: https://github.com/cdklabs/awscdk-asset-kubectl-go/tree/kubectl.20. 

This seems a bit redundant, so I want to simplify this to `kubectlv20` (and similar for other versions).

If accepted, I plan to backport this to other branches of kubectl.