### PR TITLE
fix: README has outdated APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <!--END STABILITY BANNER-->
 
-This module exports a single class called `KubectlAsset` which is an `s3_assets.Asset` that
+This module exports a single class called `KubectlLayer` which is a `lambda.LayerVersion` that
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
@@ -22,15 +22,13 @@ bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) a
 Usage:
 
 ```ts
-// KubectlAsset bundles the 'kubectl' and 'helm' command lines
-import { KubectlAsset } from '@aws-cdk/asset-kubectl-v21';
+// KubectlLayer bundles the 'kubectl' and 'helm' command lines
+import { KubectlLayer } from '@aws-cdk/asset-kubectl-v21';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 declare const fn: lambda.Function;
-const kubectl = new KubectlAsset(this, 'KubectlAsset');
-fn.addLayers(new lambda.LayerVersion(this, 'KubectlLayer', {
-  code: lambda.Code.fromBucket(kubectl.bucket, kubectl.s3ObjectKey),
-}));
+const kubectl = new KubectlLayer(this, 'KubectlLayer');
+fn.addLayers(kubectl);
 ```
 
 `kubectl` will be installed under `/opt/kubectl/kubectl`, and `helm` will be installed under `/opt/helm/helm`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Asset with KubeCtl v1.21
+# Lambda Layer with KubeCtl v1.21
 <!--BEGIN STABILITY BANNER-->
 
 ---


### PR DESCRIPTION
After updating the API in this [pull request](https://github.com/cdklabs/awscdk-asset-kubectl/pull/35), the README was out of date.