### PR TITLE
feat: include kubectl version explicitly in API

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -304,6 +304,7 @@
       "description": "Prepare a release from \"kubectl-v23/main\" branch",
       "env": {
         "RELEASE": "true",
+        "MAJOR": "2",
         "RELEASE_TAG_PREFIX": "kubectl-v23"
       },
       "steps": [

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -25,6 +25,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
       run: 'sudo chown superchain /var/run/docker.sock',
     },
   ],
+  majorVersion: 2,
   npmAccess: NpmAccess.PUBLIC,
   releaseTagPrefix: `kubectl-v${SPEC_VERSION}`,
   releaseWorkflowName: releaseWorkflowName,

--- a/API.md
+++ b/API.md
@@ -2,32 +2,32 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
-### KubectlLayer <a name="KubectlLayer" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer"></a>
+### KubectlV23Layer <a name="KubectlV23Layer" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer"></a>
 
 A CDK Asset construct that contains `kubectl` and `helm`.
 
-#### Initializers <a name="Initializers" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.Initializer"></a>
+#### Initializers <a name="Initializers" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.Initializer"></a>
 
 ```typescript
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v23'
+import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23'
 
-new KubectlLayer(scope: Construct, id: string)
+new KubectlV23Layer(scope: Construct, id: string)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.Initializer.parameter.id"></a>
 
 - *Type:* string
 
@@ -37,13 +37,13 @@ new KubectlLayer(scope: Construct, id: string)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.addPermission">addPermission</a></code> | Add permission for this layer version to specific entities. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.addPermission">addPermission</a></code> | Add permission for this layer version to specific entities. |
 
 ---
 
-##### `toString` <a name="toString" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.toString"></a>
+##### `toString` <a name="toString" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.toString"></a>
 
 ```typescript
 public toString(): string
@@ -51,7 +51,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.applyRemovalPolicy"></a>
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.applyRemovalPolicy"></a>
 
 ```typescript
 public applyRemovalPolicy(policy: RemovalPolicy): void
@@ -67,13 +67,13 @@ to be replaced.
 The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
 account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
 
-###### `policy`<sup>Required</sup> <a name="policy" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.applyRemovalPolicy.parameter.policy"></a>
+###### `policy`<sup>Required</sup> <a name="policy" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.applyRemovalPolicy.parameter.policy"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicy
 
 ---
 
-##### `addPermission` <a name="addPermission" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.addPermission"></a>
+##### `addPermission` <a name="addPermission" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.addPermission"></a>
 
 ```typescript
 public addPermission(id: string, permission: LayerVersionPermission): void
@@ -88,13 +88,13 @@ Lambda function using the layer (for example, a CloudFormation changeset
 execution role) also needs to have the ``lambda:GetLayerVersion``
 permission on the layer version.
 
-###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.addPermission.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.addPermission.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `permission`<sup>Required</sup> <a name="permission" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.addPermission.parameter.permission"></a>
+###### `permission`<sup>Required</sup> <a name="permission" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.addPermission.parameter.permission"></a>
 
 - *Type:* aws-cdk-lib.aws_lambda.LayerVersionPermission
 
@@ -104,24 +104,24 @@ permission on the layer version.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionArn">fromLayerVersionArn</a></code> | Imports a layer version by ARN. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionAttributes">fromLayerVersionAttributes</a></code> | Imports a Layer that has been defined externally. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionArn">fromLayerVersionArn</a></code> | Imports a layer version by ARN. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionAttributes">fromLayerVersionAttributes</a></code> | Imports a Layer that has been defined externally. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.isConstruct"></a>
 
 ```typescript
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v23'
+import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23'
 
-KubectlLayer.isConstruct(x: any)
+KubectlV23Layer.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -129,63 +129,63 @@ Any object.
 
 ---
 
-##### `isResource` <a name="isResource" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.isResource"></a>
+##### `isResource` <a name="isResource" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.isResource"></a>
 
 ```typescript
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v23'
+import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23'
 
-KubectlLayer.isResource(construct: IConstruct)
+KubectlV23Layer.isResource(construct: IConstruct)
 ```
 
 Check whether the given construct is a Resource.
 
-###### `construct`<sup>Required</sup> <a name="construct" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.isResource.parameter.construct"></a>
+###### `construct`<sup>Required</sup> <a name="construct" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.isResource.parameter.construct"></a>
 
 - *Type:* constructs.IConstruct
 
 ---
 
-##### `fromLayerVersionArn` <a name="fromLayerVersionArn" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionArn"></a>
+##### `fromLayerVersionArn` <a name="fromLayerVersionArn" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionArn"></a>
 
 ```typescript
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v23'
+import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23'
 
-KubectlLayer.fromLayerVersionArn(scope: Construct, id: string, layerVersionArn: string)
+KubectlV23Layer.fromLayerVersionArn(scope: Construct, id: string, layerVersionArn: string)
 ```
 
 Imports a layer version by ARN.
 
 Assumes it is compatible with all Lambda runtimes.
 
-###### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionArn.parameter.scope"></a>
+###### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionArn.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionArn.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionArn.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionArn.parameter.layerVersionArn"></a>
+###### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionArn.parameter.layerVersionArn"></a>
 
 - *Type:* string
 
 ---
 
-##### `fromLayerVersionAttributes` <a name="fromLayerVersionAttributes" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionAttributes"></a>
+##### `fromLayerVersionAttributes` <a name="fromLayerVersionAttributes" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionAttributes"></a>
 
 ```typescript
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v23'
+import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23'
 
-KubectlLayer.fromLayerVersionAttributes(scope: Construct, id: string, attrs: LayerVersionAttributes)
+KubectlV23Layer.fromLayerVersionAttributes(scope: Construct, id: string, attrs: LayerVersionAttributes)
 ```
 
 Imports a Layer that has been defined externally.
 
-###### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionAttributes.parameter.scope"></a>
+###### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionAttributes.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
@@ -193,7 +193,7 @@ the parent Construct that will use the imported layer.
 
 ---
 
-###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionAttributes.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionAttributes.parameter.id"></a>
 
 - *Type:* string
 
@@ -201,7 +201,7 @@ the id of the imported layer in the construct tree.
 
 ---
 
-###### `attrs`<sup>Required</sup> <a name="attrs" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.fromLayerVersionAttributes.parameter.attrs"></a>
+###### `attrs`<sup>Required</sup> <a name="attrs" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.fromLayerVersionAttributes.parameter.attrs"></a>
 
 - *Type:* aws-cdk-lib.aws_lambda.LayerVersionAttributes
 
@@ -213,15 +213,15 @@ the properties of the imported layer.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.compatibleRuntimes">compatibleRuntimes</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime[]</code> | The runtimes compatible with this Layer. |
-| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.layerVersionArn">layerVersionArn</a></code> | <code>string</code> | The ARN of the Lambda Layer version that this Layer defines. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.compatibleRuntimes">compatibleRuntimes</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime[]</code> | The runtimes compatible with this Layer. |
+| <code><a href="#@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.layerVersionArn">layerVersionArn</a></code> | <code>string</code> | The ARN of the Lambda Layer version that this Layer defines. |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -233,7 +233,7 @@ The tree node.
 
 ---
 
-##### `env`<sup>Required</sup> <a name="env" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.env"></a>
+##### `env`<sup>Required</sup> <a name="env" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.env"></a>
 
 ```typescript
 public readonly env: ResourceEnvironment;
@@ -252,7 +252,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### `stack`<sup>Required</sup> <a name="stack" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.stack"></a>
+##### `stack`<sup>Required</sup> <a name="stack" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.stack"></a>
 
 ```typescript
 public readonly stack: Stack;
@@ -264,7 +264,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### `compatibleRuntimes`<sup>Optional</sup> <a name="compatibleRuntimes" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.compatibleRuntimes"></a>
+##### `compatibleRuntimes`<sup>Optional</sup> <a name="compatibleRuntimes" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.compatibleRuntimes"></a>
 
 ```typescript
 public readonly compatibleRuntimes: Runtime[];
@@ -276,7 +276,7 @@ The runtimes compatible with this Layer.
 
 ---
 
-##### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlLayer.property.layerVersionArn"></a>
+##### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="@aws-cdk/lambda-layer-kubectl-v23.KubectlV23Layer.property.layerVersionArn"></a>
 
 ```typescript
 public readonly layerVersionArn: string;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ---
 
-![cdk-constructs: Experimental](https://img.shields.io/badge/cdk--constructs-experimental-important.svg?style=for-the-badge)
+![cdk-constructs: Stable](https://img.shields.io/badge/cdk--constructs-stable-success.svg?style=for-the-badge)
 
 ---
 
@@ -23,7 +23,7 @@ Usage:
 
 ```ts
 // KubectlLayer bundles the 'kubectl' and 'helm' command lines
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v23';
+import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 declare const fn: lambda.Function;

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 declare const fn: lambda.Function;
-const kubectl = new KubectlLayer(this, 'KubectlLayer');
+const kubectl = new KubectlV23Layer(this, 'KubectlLayer');
 fn.addLayers(kubectl);
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <!--END STABILITY BANNER-->
 
-This module exports a single class called `KubectlLayer` which is a `lambda.LayerVersion` that
+This module exports a single class called `KubectlV23Layer` which is a `lambda.LayerVersion` that
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 

--- a/src/kubectl-layer.ts
+++ b/src/kubectl-layer.ts
@@ -5,7 +5,7 @@ import { assetHash, ASSET_FILE } from './_asset';
 /**
  * A CDK Asset construct that contains `kubectl` and `helm`.
  */
-export class KubectlLayer extends lambda.LayerVersion {
+export class KubectlV23Layer extends lambda.LayerVersion {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
       code: lambda.Code.fromAsset(ASSET_FILE, {

--- a/test/kubectl-layer.integ.ts
+++ b/test/kubectl-layer.integ.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cr from 'aws-cdk-lib/custom-resources';
 
-import { KubectlLayer } from '../lib';
+import { KubectlV23Layer } from '../lib';
 
 /**
  * Test verifies that kubectl and helm are invoked successfully inside Lambda runtime.
@@ -11,7 +11,7 @@ import { KubectlLayer } from '../lib';
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'lambda-layer-kubectl-integ-stack');
-const layer = new KubectlLayer(stack, 'KubectlLayer');
+const layer = new KubectlV23Layer(stack, 'KubectlLayer');
 
 const runtimes = [
   lambda.Runtime.PYTHON_3_7,

--- a/test/kubectl-layer.test.ts
+++ b/test/kubectl-layer.test.ts
@@ -1,13 +1,13 @@
 import { Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { KubectlLayer } from '../lib';
+import { KubectlV23Layer } from '../lib';
 
 test('synthesized to a layer version', () => {
   // GIVEN
   const stack = new Stack();
 
   // WHEN
-  new KubectlLayer(stack, 'MyLayer');
+  new KubectlV23Layer(stack, 'MyLayer');
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {


### PR DESCRIPTION
Based on feedback from @rix0rrr, explicitly including the version number in the class name.

This PR also bumps the major version to 2.0 so that it is clear to customers that this library is compatible with AWS CDK 2.0
