### PR TITLE
chore: only release on functional updates (v24)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -32,7 +32,8 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": "kubectl-v24"
+        "RELEASE_TAG_PREFIX": "kubectl-v24",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'"
       },
       "steps": [
         {
@@ -376,7 +377,8 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": "kubectl-v24"
+        "RELEASE_TAG_PREFIX": "kubectl-v24",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'"
       },
       "steps": [
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { awscdk, Gitpod, DevEnvironmentDockerImage } from 'projen';
+import { awscdk, Gitpod, DevEnvironmentDockerImage, ReleasableCommits } from 'projen';
 import { NpmAccess } from 'projen/lib/javascript';
 import { WorkflowNoDockerPatch } from './projenrc/workflow-no-docker-patch';
 
@@ -25,6 +25,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
   npmAccess: NpmAccess.PUBLIC,
   releaseTagPrefix: `kubectl-v${SPEC_VERSION}`,
   releaseWorkflowName: releaseWorkflowName,
+  // If we don't do this we release the devDependency updates that happen every day, which blows out
+  // our PyPI storage budget even though there aren't any functional changes.
+  releasableCommits: ReleasableCommits.featuresAndFixes(),
   defaultReleaseBranch: defaultReleaseBranchName,
   publishToPypi: {
     distName: `aws-cdk.lambda-layer-kubectl-v${SPEC_VERSION}`,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jsii-pacmak": "^1.84.0",
     "jsii-rosetta": "1.x",
     "npm-check-updates": "^16",
-    "projen": "^0.71.122",
+    "projen": "^0.71.123",
     "standard-version": "^9",
     "ts-jest": "^27",
     "ts-node": "^10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5290,10 +5290,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.71.122:
-  version "0.71.122"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.122.tgz#56f013ea3d35a1d29eaa7c4b05a26a45fb8df79c"
-  integrity sha512-ued/c3CTtK77R0WoefZSi9MbV66BrjqWiRShrsh+I1RV1if+ch+pj1Mh5xn/YRLNTuR2YRovc99CGIsyNTyn+g==
+projen@^0.71.123:
+  version "0.71.123"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.123.tgz#be7b792a38e0c7e1943a21a5370c0b9bdc4f4272"
+  integrity sha512-42cJYxb0sRNXCdjVlqn/W6u7AIgGK63RA0hgnXf91O+FaWdUR+1kbukWX0RQD2JIvBLnhfhGm4GbvzrhqCFQFQ==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
We currently release this package every day, which is blowing out our PyPI budget, but there's no need to. The actual kubectl doesn't change.