### PR TITLE
chore: upgrade helm to 3.14.0

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ This module exports a single class called `KubectlV28Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.13.3
+> - Helm Version: 3.14.0
 > - Kubectl Version: 1.28.3
 >
 

--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ This module exports a single class called `KubectlV28Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.13.2
+> - Helm Version: 3.13.3
 > - Kubectl Version: 1.28.3
 >
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module exports a single class called `KubectlV28Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.13.3
+> - Helm Version: 3.14.0
 > - Kubectl Version: 1.28.3
 >
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module exports a single class called `KubectlV28Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.13.2
+> - Helm Version: 3.13.3
 > - Kubectl Version: 1.28.3
 >
 

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/lambda/provided:latest
 #
 
 ARG KUBECTL_VERSION=1.28.3
-ARG HELM_VERSION=3.13.3
+ARG HELM_VERSION=3.14.0
 
 USER root
 RUN mkdir -p /opt

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/lambda/provided:latest
 #
 
 ARG KUBECTL_VERSION=1.28.3
-ARG HELM_VERSION=3.13.2
+ARG HELM_VERSION=3.13.3
 
 USER root
 RUN mkdir -p /opt

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "20.0.0",
   "files": {
-    "86f05776482372fd66a81138275ca1022ffed8dd49d94a7043447e754005e700": {
+    "bdb2015ec68b53161d29e5910113dcb0b789ba26659fcfdcddddf8256bde19ef": {
       "source": {
-        "path": "asset.86f05776482372fd66a81138275ca1022ffed8dd49d94a7043447e754005e700.zip",
+        "path": "asset.bdb2015ec68b53161d29e5910113dcb0b789ba26659fcfdcddddf8256bde19ef.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "86f05776482372fd66a81138275ca1022ffed8dd49d94a7043447e754005e700.zip",
+          "objectKey": "bdb2015ec68b53161d29e5910113dcb0b789ba26659fcfdcddddf8256bde19ef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "86e18474711dc6dbd3f6177635ac32b37d05874c66fb96820dbe2f2a63462017": {
+    "2eb36619c7130ec6c6d3b20cc4a61564c10cbab61c464356eba878419de02659": {
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "86e18474711dc6dbd3f6177635ac32b37d05874c66fb96820dbe2f2a63462017.json",
+          "objectKey": "2eb36619c7130ec6c6d3b20cc4a61564c10cbab61c464356eba878419de02659.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,7 +7,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "86f05776482372fd66a81138275ca1022ffed8dd49d94a7043447e754005e700.zip"
+     "S3Key": "bdb2015ec68b53161d29e5910113dcb0b789ba26659fcfdcddddf8256bde19ef.zip"
     },
     "Description": "/opt/kubectl/kubectl 1.28; /opt/helm/helm 3.13",
     "LicenseInfo": "Apache-2.0"


### PR DESCRIPTION
Fixes https://github.com/cdklabs/awscdk-asset-kubectl/issues/489