### PR TITLE
chore: update helm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module bundles the
 `ASSET_FILE` and `LAYER_SOURCE_DIR` that can be consumed via the cdk `Asset`
 construct.
 
-> - Helm Version: 3.8.1
+> - Helm Version: 3.17.0
 > - Kubectl Version: 1.20.0
 > 
 

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -7,8 +7,11 @@ FROM public.ecr.aws/lambda/provided:latest
 
 # KUBECTL_VERSION should not be changed at the moment, see https://github.com/aws/aws-cdk/issues/15736
 # Version 1.21.0 is not compatible with version 1.20 (and lower) of the server.
+# Setting helm version to 3.17.0 to mitigate https://security.snyk.io/vuln/SNYK-CHAINGUARDLATEST-HELM-7219926
+# It is not guaranteed to work with the kubectl version. However this layer version is outdated so it doesn't really matter.
+# This needs to be fixed because the outdated version is bundled into cdk dependency.
 ARG KUBECTL_VERSION=1.20.0 
-ARG HELM_VERSION=3.8.1
+ARG HELM_VERSION=3.17.0
 
 USER root
 RUN mkdir -p /opt

--- a/test/kubectl-asset.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-asset.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "38.0.1",
   "files": {
-    "e35d06c04a5f086530cad7876451b9fbd93ded1d4940950bb104fb78dd322310": {
+    "4a9eead4730e5ced9df7c65a4ead6796d8a12930aea73afa6484da8f982f9cf5": {
       "source": {
-        "path": "asset.e35d06c04a5f086530cad7876451b9fbd93ded1d4940950bb104fb78dd322310.zip",
+        "path": "asset.4a9eead4730e5ced9df7c65a4ead6796d8a12930aea73afa6484da8f982f9cf5.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e35d06c04a5f086530cad7876451b9fbd93ded1d4940950bb104fb78dd322310.zip",
+          "objectKey": "4a9eead4730e5ced9df7c65a4ead6796d8a12930aea73afa6484da8f982f9cf5.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "f556204d1443466ffdd864c68846e169b2ab550aa30349dc069545bae8f31db2": {
+    "0580c2d6bc62ee96aa188c0098eebf72ba5326065971183c7f944019c82c6094": {
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f556204d1443466ffdd864c68846e169b2ab550aa30349dc069545bae8f31db2.json",
+          "objectKey": "0580c2d6bc62ee96aa188c0098eebf72ba5326065971183c7f944019c82c6094.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-asset.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-asset.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,7 +7,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "e35d06c04a5f086530cad7876451b9fbd93ded1d4940950bb104fb78dd322310.zip"
+     "S3Key": "4a9eead4730e5ced9df7c65a4ead6796d8a12930aea73afa6484da8f982f9cf5.zip"
     },
     "Description": "/opt/kubectl/kubectl and /opt/helm/helm"
    }


### PR DESCRIPTION
Note: This helm version is not guaranteed to work with the kubectl version in this branch.

However this layer version is outdated and not supposed to be used anymore. Helm version needs to be updated because it's impacted by the CVE https://security.snyk.io/vuln/SNYK-CHAINGUARDLATEST-HELM-7219926

It's bundled as dependency of CDK. If it's not fixed here, we need to ship a breaking change in main cdk repo which has more impact.

