### PR TITLE
feat: helm upgrade to 3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module exports a single class called `KubectlV31Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.16.1
+> - Helm Version: 3.17.0
 > - Kubectl Version: 1.31.0
 >
 
@@ -21,7 +21,7 @@ Usage:
 
 ```ts
 // KubectlLayer bundles the 'kubectl' and 'helm' command lines
-import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v29';
+import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 declare const fn: lambda.Function;

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/lambda/provided:latest
 #
 
 ARG KUBECTL_VERSION=1.31.0
-ARG HELM_VERSION=3.16.1
+ARG HELM_VERSION=3.17.0
 
 USER root
 RUN mkdir -p /opt

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "34.0.0",
   "files": {
-    "f3c812b299b0759c937b41e39d3451f5cc61279c2ec9ee791fac08ba1e56508b": {
+    "92de4f0850ca1327781e1e19c8ad80951f01ab1b499c91f8d0fb8b3e7bf5b895": {
       "source": {
-        "path": "asset.f3c812b299b0759c937b41e39d3451f5cc61279c2ec9ee791fac08ba1e56508b.zip",
+        "path": "asset.92de4f0850ca1327781e1e19c8ad80951f01ab1b499c91f8d0fb8b3e7bf5b895.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f3c812b299b0759c937b41e39d3451f5cc61279c2ec9ee791fac08ba1e56508b.zip",
+          "objectKey": "92de4f0850ca1327781e1e19c8ad80951f01ab1b499c91f8d0fb8b3e7bf5b895.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "7ea6685a38548ef8f66ea72b5829b3a6ba4ea5498b30c28001dbd94f984f9e9a": {
+    "e53acf4b865ecb5c2cd992b7d51256c28e6bf16507079880e6c1fcc1a2c20f7c": {
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7ea6685a38548ef8f66ea72b5829b3a6ba4ea5498b30c28001dbd94f984f9e9a.json",
+          "objectKey": "e53acf4b865ecb5c2cd992b7d51256c28e6bf16507079880e6c1fcc1a2c20f7c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,7 +7,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "f3c812b299b0759c937b41e39d3451f5cc61279c2ec9ee791fac08ba1e56508b.zip"
+     "S3Key": "92de4f0850ca1327781e1e19c8ad80951f01ab1b499c91f8d0fb8b3e7bf5b895.zip"
     },
     "Description": "/opt/kubectl/kubectl 1.31.0; /opt/helm/helm 3.16.1",
     "LicenseInfo": "Apache-2.0"


### PR DESCRIPTION
Fixes #1538 

This applies appropriate version upgrades for the helm version to upgrade on the v31 branch.  This can be replicated back if necessary to other kubectl versions.