### PR TITLE
fix: refine the new version release process (backport of #1620)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Asset in the issue.
 2. If we decide to support the requested version, a maintainer will open a new branch, `kubectl-vY/main`
 (Y is the minor version) and update the issue accordingly. The maintainer will also open a branch called `kubectl.vY`
 in the corresponding go binding repository, [`cdklabs/awscdk-kubectl-go`](https://github.com/cdklabs/awscdk-kubectl-go/branches).
-3. Fork the repository and fetch the `kubectl-vY/main` branch locally, and modify the source off of that.
+3. Create a fork of the repository and fetch the `kubectl-vY/main` branch locally, and modify the source off of that.
 4. Specifically: 
     - change `README.md` to reflect the new versions of kubectl and helm that the asset will include.
     - change `KUBECTL_VERSION` and `HELM_VERSION` in `layer/Dockerfile` to reflect the new versions.
@@ -64,18 +64,24 @@ in the corresponding go binding repository, [`cdklabs/awscdk-kubectl-go`](https:
     `KUBECTL_VERSION` is v1.20.x, then the `HELM_VERSION` should be v3.8.x.
     - change `SPEC_VERSION` in `.projenrc.js` to reflect the new minor version of kubectl.
     For example, if `KUBECTL_VERSION` is v1.25.0, then `SPEC_VERSION` should be 25.
-    - for an example of code changes done for kubectl v1.22.0, see this [PR](https://github.com/cdklabs/awscdk-asset-kubectl/pull/7).
-5. Run `npx projen` to update the github workflows.
-6. Run `npx projen integ:kubectl-layer:deploy` to ensure that the new versions in the Dockerfile can be successfully downloaded.
-Run `npx projen integ:kubectl-layer:snapshot` if `deploy` succeeds and the snapshot does not get updated.
-7. Run `yarn build` to ensure everything builds correctly.
-8. Commit to your fork and submit a pull request to the repository, _ensuring that you are targeting the correct `kubectl-vY/main` branch_.
-9. A maintainer will review your contribution from there!
-10. ⚠️ IMPORTANT ⚠️ The maintainer should go into the repository settings and update the default branch to the new, latest version.
+    - change the Kubectl Lambda layer class in `src/kubectl-layer.ts` to `KubectlV##Layer`, and its `description` field to reflect the latest versions of Kubectl and Helm being supported.
+    - change `test/kubectl-layer.test.ts` to reflect the new construct's name (changed in the previous step) and that the description
+    verifies the correct versions of Kubectl and Helm.
+    - change `test/kubectl-layer.integ.ts` to reflect the new construct's name (changed in the previous step).
+    - for an example of code changes done for Kubectl v1.22.0, see this [PR](https://github.com/cdklabs/awscdk-asset-kubectl/pull/7).
+5. Run `npx projen compile` to generate the Lambda layer constructs that will be tested.
+6. Run `npx projen` to update the github workflows.
+7. Run `npx projen integ:kubectl-layer:deploy` to ensure that the new versions in the Dockerfile can be successfully downloaded.
+This stage _must succeed_ before proceeding. 
+When it succeeds, confirm that the snapshot in `test/kubectl-layer.integ.snapshot` has been updated. If not, run `npx projen integ:kubectl-layer:snapshot` to update it.
+8. Run `yarn build` to ensure everything builds correctly.
+9. Commit to your fork and submit a pull request to the repository, _ensuring that you are targeting the correct `kubectl-vY/main` branch_.
+10. A maintainer will review your contribution from there!
+11. ⚠️ **IMPORTANT FOR THE MAINTAINER** ⚠️ The maintainer should go into the repository settings and update the default branch to this new, latest version that has just been merged in. This is because GitHub only runs actions on default branches, and we want to ensure dependencies are updated in the latest version + the previous 3 versions.
 
 ## Backporting changes to branches with different Kubectl versions
 This repository consists of multiple branches, with each branch corresponding to a specific Kubectl version.
-For example, `kubectl-v24/main` is the branch that releases a Lambda Layer that bundles kubectl version 1.24.
+For example, `kubectl-v24/main` is the branch that releases a Lambda Layer that bundles Kubectl version 1.24.
 Sometimes, a contribution made to a specific branch should be propogated to other branches in this repository as well.
 To do this, you can add `backport-to-kubectl-v21+` as a label to the PR that tells Mergify to backport when the PR is merged.
 This will backport to all versions of kubectl except kubectl v1.20, which is special and does not expose a Lambda Layer.

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -24,8 +24,9 @@ RUN dnf update -y \
 #
 
 RUN mkdir -p /opt/kubectl
-RUN cd /opt/kubectl && curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+RUN cd /opt/kubectl && curl -LO "https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
 RUN chmod +x /opt/kubectl/kubectl
+RUN /opt/kubectl/kubectl config view
 
 #
 # helm
@@ -33,6 +34,7 @@ RUN chmod +x /opt/kubectl/kubectl
 
 RUN mkdir -p /tmp/helm && wget -qO- https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -xvz -C /tmp/helm
 RUN mkdir -p /opt/helm && cp /tmp/helm/linux-amd64/helm /opt/helm/helm
+RUN /opt/helm/helm version
 
 #
 # create the bundle

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "32.0.0",
   "files": {
-    "0afbe25a9ce0197a83dffd77a86c1560704da246373a4ccafde5476e7e3d0811": {
+    "bf90d3130a5975853500064ac9781484a679d171b5d763e02144668b9fe0b5d2": {
       "source": {
-        "path": "asset.0afbe25a9ce0197a83dffd77a86c1560704da246373a4ccafde5476e7e3d0811.zip",
+        "path": "asset.bf90d3130a5975853500064ac9781484a679d171b5d763e02144668b9fe0b5d2.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0afbe25a9ce0197a83dffd77a86c1560704da246373a4ccafde5476e7e3d0811.zip",
+          "objectKey": "bf90d3130a5975853500064ac9781484a679d171b5d763e02144668b9fe0b5d2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "4b7391709d14a9e6ad5a8337e3834c15115e87b2a7b57bb603aa7400a86ab2de": {
+    "16b47a359fa396094617e01fac0e312d5ca684d99a5198fd9fa8c384867fb31a": {
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4b7391709d14a9e6ad5a8337e3834c15115e87b2a7b57bb603aa7400a86ab2de.json",
+          "objectKey": "16b47a359fa396094617e01fac0e312d5ca684d99a5198fd9fa8c384867fb31a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,7 +7,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "0afbe25a9ce0197a83dffd77a86c1560704da246373a4ccafde5476e7e3d0811.zip"
+     "S3Key": "bf90d3130a5975853500064ac9781484a679d171b5d763e02144668b9fe0b5d2.zip"
     },
     "Description": "/opt/kubectl/kubectl 1.30; /opt/helm/helm 3.15",
     "LicenseInfo": "Apache-2.0"


### PR DESCRIPTION
Literally just the same changes I made in #1620 but they didn't work in #1622 for some reason because the build kept failing, even though it passed locally on my machine? Hopefully it was some error in the backporting script and this fixes that.