### PR TITLE
feat: upgrade kubectl to 1.31.9, helm to 3.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This module exports a single class called `KubectlV31Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.17.1
-> - Kubectl Version: 1.31.0
+> - Helm Version: 3.17.3
+> - Kubectl Version: 1.31.9
 >
 
 Usage:

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -5,8 +5,8 @@ FROM public.ecr.aws/lambda/provided:latest
 # versions
 #
 
-ARG KUBECTL_VERSION=1.31.0
-ARG HELM_VERSION=3.17.1
+ARG KUBECTL_VERSION=1.31.9
+ARG HELM_VERSION=3.17.3
 
 USER root
 RUN mkdir -p /opt

--- a/src/kubectl-layer.ts
+++ b/src/kubectl-layer.ts
@@ -11,7 +11,7 @@ export class KubectlV31Layer extends lambda.LayerVersion {
       code: lambda.Code.fromAsset(ASSET_FILE, {
         assetHash: assetHash(),
       }),
-      description: '/opt/kubectl/kubectl 1.31.0; /opt/helm/helm 3.17.1',
+      description: '/opt/kubectl/kubectl 1.31.9; /opt/helm/helm 3.17.3',
       license: 'Apache-2.0',
     });
   }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "34.0.0",
   "files": {
-    "a5110b475e7a506b8a1282cdfb3c2f7ae59bcf00ba96273a702339b8819dd17f": {
+    "77675805670406a68c1baf43392c7e699bee435fe9b667ef4f9f1134b8c41d0e": {
       "source": {
-        "path": "asset.a5110b475e7a506b8a1282cdfb3c2f7ae59bcf00ba96273a702339b8819dd17f.zip",
+        "path": "asset.77675805670406a68c1baf43392c7e699bee435fe9b667ef4f9f1134b8c41d0e.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a5110b475e7a506b8a1282cdfb3c2f7ae59bcf00ba96273a702339b8819dd17f.zip",
+          "objectKey": "77675805670406a68c1baf43392c7e699bee435fe9b667ef4f9f1134b8c41d0e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "a89b591963cfeabc1e51059ec0e14ad837f5606dce372bd26c478f1c0fe6f72f": {
+    "e8164cb7cac6e752e73e0abee75e8c734929b9e84bcf7057d55f4d917da51bea": {
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a89b591963cfeabc1e51059ec0e14ad837f5606dce372bd26c478f1c0fe6f72f.json",
+          "objectKey": "e8164cb7cac6e752e73e0abee75e8c734929b9e84bcf7057d55f4d917da51bea.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,9 +7,9 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "a5110b475e7a506b8a1282cdfb3c2f7ae59bcf00ba96273a702339b8819dd17f.zip"
+     "S3Key": "77675805670406a68c1baf43392c7e699bee435fe9b667ef4f9f1134b8c41d0e.zip"
     },
-    "Description": "/opt/kubectl/kubectl 1.31.0; /opt/helm/helm 3.17.1",
+    "Description": "/opt/kubectl/kubectl 1.31.9; /opt/helm/helm 3.17.3",
     "LicenseInfo": "Apache-2.0"
    }
   },

--- a/test/kubectl-layer.test.ts
+++ b/test/kubectl-layer.test.ts
@@ -11,7 +11,7 @@ test('synthesized to a layer version', () => {
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-    Description: '/opt/kubectl/kubectl 1.31.0; /opt/helm/helm 3.17.1',
+    Description: '/opt/kubectl/kubectl 1.31.9; /opt/helm/helm 3.17.3',
   });
 });
 


### PR DESCRIPTION
## Description
- upgrade kubectl to [**1.31.9**](https://github.com/kubernetes/kubernetes/releases)
- upgrade helm to [**3.17.3**](https://github.com/helm/helm/releases)