### PR TITLE
chore: updating the list of supported branches for backport

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,14 +18,15 @@ queue_rules:
 
       {{ body }}
 pull_request_rules:
-  - name: backport patches to kubectl-v21+ branches
+  - name: backport patches to supported branches
     conditions:
-      - label=backport-to-kubectl-v21+
+      - label=backport-to-supported-branches
       - base=kubectl-v33/main
     actions:
       backport:
-        regexes:
-          - kubectl-v(?!20|33)[\d]*\/main
+        branches:
+          - kubectl-v32/main
+          - kubectl-v31/main
         labels:
           - auto-approve
   - name: Automatic merge on approval and successful build

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -7,6 +7,22 @@ const SPEC_VERSION = '33';
 const releaseWorkflowName = `release-kubectl-v${SPEC_VERSION}`;
 const defaultReleaseBranchName = `kubectl-v${SPEC_VERSION}/main`;
 
+// v20 must be support because aws-cdk-lib depends on it
+const V20_BRANCH_MUST_BE_SUPPORTED = 'kubectl-v20/main';
+const CURRENT_BRANCH = `kubectl-v${SPEC_VERSION}/main`;
+
+// Define supported branches for reuse across the configuration
+const SUPPORTED_BRANCHES = [
+  V20_BRANCH_MUST_BE_SUPPORTED,
+  CURRENT_BRANCH,
+  `kubectl-v${Number(SPEC_VERSION)-1}/main`,
+  `kubectl-v${Number(SPEC_VERSION)-2}/main`,
+];
+
+// Get backport target branches (supported branches excluding v20 and current version)
+const BACKPORT_TARGET_BRANCHES = SUPPORTED_BRANCHES
+  .filter(branch => !(branch == V20_BRANCH_MUST_BE_SUPPORTED || branch === CURRENT_BRANCH));
+
 const project = new awscdk.AwsCdkConstructLibrary({
   projenrcTs: true,
   author: 'Amazon Web Services',
@@ -25,12 +41,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   // We also need to keep supporting v20 since it is a hard dependency of aws-cdk-lib
   depsUpgradeOptions: {
     workflowOptions: {
-      branches: [
-        'kubectl-v20/main', // this must be supported because aws-cdk-lib depends on it
-        `kubectl-v${SPEC_VERSION}/main`,
-        `kubectl-v${Number(SPEC_VERSION)-1}/main`,
-        `kubectl-v${Number(SPEC_VERSION)-2}/main`,
-      ],
+      branches: SUPPORTED_BRANCHES,
       labels: ['auto-approve'],
     },
   },
@@ -67,14 +78,14 @@ const project = new awscdk.AwsCdkConstructLibrary({
   githubOptions: {
     mergifyOptions: {
       rules: [{
-        name: 'backport patches to kubectl-v21+ branches',
+        name: 'backport patches to supported branches',
         conditions: [
-          'label=backport-to-kubectl-v21+',
-          `base=kubectl-v${SPEC_VERSION}/main`,
+          'label=backport-to-supported-branches',
+          `base=${CURRENT_BRANCH}`, // Current version branch
         ],
         actions: {
           backport: {
-            regexes: [`kubectl-v(?!20|${SPEC_VERSION})[\\d]*\\/main`],
+            branches: BACKPORT_TARGET_BRANCHES,
             labels: ['auto-approve'],
           },
         },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ branch called `kubectl.vY`in the corresponding go binding repository, [`cdklabs/
 This repository consists of multiple branches, with each branch corresponding to a specific Kubectl version.
 For example, `kubectl-v24/main` is the branch that releases a Lambda Layer that bundles Kubectl version 1.24.
 Sometimes, a contribution made to a specific branch should be propogated to other branches in this repository as well.
-To do this, you can add `backport-to-kubectl-v21+` as a label to the PR that tells Mergify to backport when the PR is merged.
+To do this, you can add `backport-to-supported-branches` as a label to the PR that tells Mergify to backport when the PR is merged.
 This will backport to all versions of kubectl except kubectl v1.20, which is special and does not expose a Lambda Layer.
 
 If you think you need to backport to a specific subset of branches instead, you can ask a maintainer to backport via


### PR DESCRIPTION
There are several PRs which attempt to backport changes to unsupported versions:
https://github.com/cdklabs/awscdk-asset-kubectl/pull/2011
https://github.com/cdklabs/awscdk-asset-kubectl/pull/2012
https://github.com/cdklabs/awscdk-asset-kubectl/pull/2013
https://github.com/cdklabs/awscdk-asset-kubectl/pull/2014
https://github.com/cdklabs/awscdk-asset-kubectl/pull/2015

Updating the backport logic to use the correct [list of supported branches](https://github.com/cdklabs/awscdk-asset-kubectl/blob/kubectl-v33/main/.projenrc.ts#L29-L32) for all operations, to ensure these remain up-to-date.
