### PR TITLE
feat: add kubectl v1.35.0 with helm v4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module exports a single class called `KubectlV35Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 3.19.0
+> - Helm Version: 4.1.0
 > - Kubectl Version: 1.35.0
 >
 

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/lambda/provided:latest
 #
 
 ARG KUBECTL_VERSION=1.35.0
-ARG HELM_VERSION=3.19.0
+ARG HELM_VERSION=4.1.0
 
 USER root
 RUN mkdir -p /opt

--- a/src/kubectl-layer.ts
+++ b/src/kubectl-layer.ts
@@ -11,7 +11,7 @@ export class KubectlV35Layer extends lambda.LayerVersion {
       code: lambda.Code.fromAsset(ASSET_FILE, {
         assetHash: assetHash(),
       }),
-      description: '/opt/kubectl/kubectl 1.35.0; /opt/helm/helm 3.19.0',
+      description: '/opt/kubectl/kubectl 1.35.0; /opt/helm/helm 4.1.0',
       license: 'Apache-2.0',
     });
   }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "34.0.0",
   "files": {
-    "ba43b5533b0e9e1519e396580e01a14d2acf810921874c3681d563429cac24bf": {
+    "5ab5551b933f2170cd0fcc2e293efb7e33a64d04c22cc03343242c843e4e4034": {
       "source": {
-        "path": "asset.ba43b5533b0e9e1519e396580e01a14d2acf810921874c3681d563429cac24bf.zip",
+        "path": "asset.5ab5551b933f2170cd0fcc2e293efb7e33a64d04c22cc03343242c843e4e4034.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ba43b5533b0e9e1519e396580e01a14d2acf810921874c3681d563429cac24bf.zip",
+          "objectKey": "5ab5551b933f2170cd0fcc2e293efb7e33a64d04c22cc03343242c843e4e4034.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "9c0e2c496949b24a5f07bb3da4758c426d284a9e9b36d6cbd788438bb4939a6c": {
+    "2ad1d022b23b0c5a502c32b45f95384679419e528ba6f590a9f4f4b16b8dccee": {
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9c0e2c496949b24a5f07bb3da4758c426d284a9e9b36d6cbd788438bb4939a6c.json",
+          "objectKey": "2ad1d022b23b0c5a502c32b45f95384679419e528ba6f590a9f4f4b16b8dccee.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,9 +7,9 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "ba43b5533b0e9e1519e396580e01a14d2acf810921874c3681d563429cac24bf.zip"
+     "S3Key": "5ab5551b933f2170cd0fcc2e293efb7e33a64d04c22cc03343242c843e4e4034.zip"
     },
-    "Description": "/opt/kubectl/kubectl 1.35.0; /opt/helm/helm 3.19.0",
+    "Description": "/opt/kubectl/kubectl 1.35.0; /opt/helm/helm 4.1.0",
     "LicenseInfo": "Apache-2.0"
    }
   },

--- a/test/kubectl-layer.test.ts
+++ b/test/kubectl-layer.test.ts
@@ -11,6 +11,6 @@ test('synthesized to a layer version', () => {
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-    Description: '/opt/kubectl/kubectl 1.35.0; /opt/helm/helm 3.19.0',
+    Description: '/opt/kubectl/kubectl 1.35.0; /opt/helm/helm 4.1.0',
   });
 });


### PR DESCRIPTION
Adds support for kubectl v1.35.0 with helm v4.1.0.

## Changes
- kubectl v1.35.0
- helm v4.1.0 (Helm 4.1.x officially supports kubectl 1.35.x per [Helm docs](https://helm.sh/docs/topics/version_skew/))
- Updated all tests and snapshots
- Lambda layer rebuilt and verified (36MB)

## Testing
- All unit tests pass
- Integration test snapshots updated
- Docker layer builds successfully
- Verified helm binary version: v4.1.0
- Verified kubectl binary version: v1.35.0

Fixes #2650