### PR TITLE
feat: enable trusted publishing for npm and PyPI

### DIFF
--- a/.github/workflows/release-kubectl-v35.yml
+++ b/.github/workflows/release-kubectl-v35.yml
@@ -131,7 +131,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   release_maven:
     name: Publish to Maven Central
@@ -185,6 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -217,8 +218,7 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi
   release_nuget:
     name: Publish to NuGet Gallery

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -47,6 +47,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   majorVersion: 2,
   npmAccess: NpmAccess.PUBLIC,
+  npmTrustedPublishing: true,
   releaseTagPrefix: `kubectl-v${SPEC_VERSION}`,
   releaseWorkflowName: releaseWorkflowName,
   // If we don't do this we release the devDependency updates that happen every day, which blows out
@@ -56,6 +57,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   publishToPypi: {
     distName: `aws-cdk.lambda-layer-kubectl-v${SPEC_VERSION}`,
     module: `aws_cdk.lambda_layer_kubectl_v${SPEC_VERSION}`,
+    trustedPublishing: true,
   },
   publishToMaven: {
     javaPackage: `software.amazon.awscdk.cdk.lambdalayer.kubectl.v${SPEC_VERSION}`,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jsii-docgen": "^10.5.0",
     "jsii-pacmak": "^1.126.0",
     "jsii-rosetta": "~5.8.0",
-    "projen": "^0.99.11",
+    "projen": "^0.99.12",
     "ts-jest": "^27",
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4649,10 +4649,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-projen@^0.99.11:
-  version "0.99.11"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.99.11.tgz#97e96856704933449e2e9a0d44aacf31ffdc83a5"
-  integrity sha512-F9HY1eAGymjtulRPpAgeO/rltcCb6x8UgiIwlTnKM7olc1CrOx9UWHxayWYJ/r/Qxrr/xbwdrtjtv4FZZKM6ww==
+projen@^0.99.12:
+  version "0.99.12"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.99.12.tgz#7cfecfc0c93f23ca72fd4254c2260df07fba93d5"
+  integrity sha512-wfOKE8tJ46wKz4SgBoJ5sK+4OcX+BscfZdXoTw7dVEKh7MpnJXqD6/GgRs0iT78e6Z0pkwGaYQK6m1OuhCHVpw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
Enables trusted publishing for npm and PyPI 

Changes:
- Enable npm trusted publishing (removes NPM_TOKEN requirement)
- Enable PyPI trusted publishing (removes TWINE_USERNAME/TWINE_PASSWORD requirement)
- Upgrade projen to 0.99.12 
