### PR TITLE
chore: set stability to stable

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,6 +36,7 @@ const project = new CdklabsConstructLibrary({
   private: false,
   setNodeEngineVersion: false,
   npmAccess: javascript.NpmAccess.PUBLIC,
+  stability: 'stable',
   autoApproveOptions: {
     allowedUsernames: ['aws-cdk-automation', 'mergify[bot]'],
     secret: 'GITHUB_TOKEN',

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     }
   },
   "types": "lib/index.d.ts",
-  "stability": "experimental",
+  "stability": "stable",
   "jsii": {
     "outdir": "dist",
     "targets": {


### PR DESCRIPTION
This PR sets the stability of the project to stable by adding the `stability: 'stable'` configuration to .projenrc.ts and regenerating all project files.