### PR TITLE
fix(test): update integ snapshot for cloud-assembly-schema v53

### DIFF
--- a/test/kubectl-asset.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-asset.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "52.0.0",
+  "version": "53.0.0",
   "files": {
     "07aae4eff01fbf4a54ce6dc5c34000cf2a6c6e18567992cf42e549ac25a80afe": {
       "displayName": "layer-asset",


### PR DESCRIPTION
The upgrade deps PR #2712 is blocked because the integ snapshot has a stale cloud-assembly-schema version (52.0.0 → 53.0.0). This updates the snapshot on main so the upgrade PR can pass CI after rebase.