### PR TITLE
fix: bump helm 4.1.3 to 4.1.4

### DIFF
--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/lambda/provided:latest
 #
 
 ARG KUBECTL_VERSION=1.33.9
-ARG HELM_VERSION=4.1.3
+ARG HELM_VERSION=4.1.4
 
 USER root
 RUN mkdir -p /opt

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,16 +1,16 @@
 {
   "version": "48.0.0",
   "files": {
-    "72b491c696d879ecf0fe6f35baa25e441e0a7bdd4983b728451e63ca31320b9b": {
+    "425acea7c9d553d1255de73b53b467930576aeca2ec2d1ac8a1a48350a4a8898": {
       "displayName": "KubectlLayer/Code",
       "source": {
-        "path": "asset.72b491c696d879ecf0fe6f35baa25e441e0a7bdd4983b728451e63ca31320b9b.zip",
+        "path": "asset.425acea7c9d553d1255de73b53b467930576aeca2ec2d1ac8a1a48350a4a8898.zip",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-e6c2e78a": {
+        "current_account-current_region-2791295a": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "72b491c696d879ecf0fe6f35baa25e441e0a7bdd4983b728451e63ca31320b9b.zip",
+          "objectKey": "425acea7c9d553d1255de73b53b467930576aeca2ec2d1ac8a1a48350a4a8898.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -43,16 +43,16 @@
         }
       }
     },
-    "28ad50d168185021b0508bd0b0f2e4e3db3be98fd76aee40de763ed3d199fca1": {
+    "45513d4ad2ecec9fd53b3d693e2929e4e332429728aace44b83c7011b3eebd6d": {
       "displayName": "lambda-layer-kubectl-integ-stack Template",
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-c7f9ccb1": {
+        "current_account-current_region-2883b3fa": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "28ad50d168185021b0508bd0b0f2e4e3db3be98fd76aee40de763ed3d199fca1.json",
+          "objectKey": "45513d4ad2ecec9fd53b3d693e2929e4e332429728aace44b83c7011b3eebd6d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,7 +7,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "72b491c696d879ecf0fe6f35baa25e441e0a7bdd4983b728451e63ca31320b9b.zip"
+     "S3Key": "425acea7c9d553d1255de73b53b467930576aeca2ec2d1ac8a1a48350a4a8898.zip"
     },
     "Description": "/opt/kubectl/kubectl 1.33.0; /opt/helm/helm 4.1.3",
     "LicenseInfo": "Apache-2.0"


### PR DESCRIPTION
Bumps `HELM_VERSION` from 4.1.3 to 4.1.4 to address:

- CVE-2026-35204 (HIGH 8.6) - helm plugin path traversal
- CVE-2026-35205 (HIGH 7.8) - helm plugin signature bypass
- CVE-2026-35206 (MEDIUM 4.4) - helm chart untar path escape

Helm 4.1.4 has been GA since 2026-04-09.

