### PR TITLE
fix: update kubectl to 1.36.3 and helm to 4.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This module exports a single class called `KubectlV36Layer` which is a `lambda.L
 bundles the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) and the
 [`helm`](https://helm.sh/) command line.
 
-> - Helm Version: 4.2.2
-> - Kubectl Version: 1.36.2
+> - Helm Version: 4.2.3
+> - Kubectl Version: 1.36.3
 >
 
 Usage:

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -5,8 +5,8 @@ FROM public.ecr.aws/lambda/provided:latest
 # versions
 #
 
-ARG KUBECTL_VERSION=1.36.2
-ARG HELM_VERSION=4.2.2
+ARG KUBECTL_VERSION=1.36.3
+ARG HELM_VERSION=4.2.3
 
 USER root
 RUN mkdir -p /opt

--- a/src/kubectl-layer.ts
+++ b/src/kubectl-layer.ts
@@ -11,7 +11,7 @@ export class KubectlV36Layer extends lambda.LayerVersion {
       code: lambda.Code.fromAsset(ASSET_FILE, {
         assetHash: assetHash(),
       }),
-      description: '/opt/kubectl/kubectl 1.36.2; /opt/helm/helm 4.2.2',
+      description: '/opt/kubectl/kubectl 1.36.3; /opt/helm/helm 4.2.3',
       license: 'Apache-2.0',
     });
   }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.assets.json
@@ -1,16 +1,16 @@
 {
   "version": "48.0.0",
   "files": {
-    "7b1571a09ac85af63b34b2c5c884dd7cd2e5508e8a6e01b67b33597d8af176f4": {
+    "1bafa5cc7c5715cb55d1b3fa2755b20db63c75d154ba9a23604c103568491420": {
       "displayName": "KubectlLayer/Code",
       "source": {
-        "path": "asset.7b1571a09ac85af63b34b2c5c884dd7cd2e5508e8a6e01b67b33597d8af176f4.zip",
+        "path": "asset.1bafa5cc7c5715cb55d1b3fa2755b20db63c75d154ba9a23604c103568491420.zip",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-6c47380d": {
+        "current_account-current_region-ce03a233": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7b1571a09ac85af63b34b2c5c884dd7cd2e5508e8a6e01b67b33597d8af176f4.zip",
+          "objectKey": "1bafa5cc7c5715cb55d1b3fa2755b20db63c75d154ba9a23604c103568491420.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -43,16 +43,16 @@
         }
       }
     },
-    "8c9a248b3e3932652e63a0de5710a625daf29fac25686fde76341862db42ea0a": {
+    "5c880ff7b6af76270f632fa1ea38c5a4dcaae9c2824d6b2d5c73094816b44ffa": {
       "displayName": "lambda-layer-kubectl-integ-stack Template",
       "source": {
         "path": "lambda-layer-kubectl-integ-stack.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-a8adbddc": {
+        "current_account-current_region-15108fb6": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8c9a248b3e3932652e63a0de5710a625daf29fac25686fde76341862db42ea0a.json",
+          "objectKey": "5c880ff7b6af76270f632fa1ea38c5a4dcaae9c2824d6b2d5c73094816b44ffa.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
+++ b/test/kubectl-layer.integ.snapshot/lambda-layer-kubectl-integ-stack.template.json
@@ -7,9 +7,9 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "7b1571a09ac85af63b34b2c5c884dd7cd2e5508e8a6e01b67b33597d8af176f4.zip"
+     "S3Key": "1bafa5cc7c5715cb55d1b3fa2755b20db63c75d154ba9a23604c103568491420.zip"
     },
-    "Description": "/opt/kubectl/kubectl 1.36.2; /opt/helm/helm 4.2.2",
+    "Description": "/opt/kubectl/kubectl 1.36.3; /opt/helm/helm 4.2.3",
     "LicenseInfo": "Apache-2.0"
    }
   },

--- a/test/kubectl-layer.test.ts
+++ b/test/kubectl-layer.test.ts
@@ -11,6 +11,6 @@ test('synthesized to a layer version', () => {
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-    Description: '/opt/kubectl/kubectl 1.36.2; /opt/helm/helm 4.2.2',
+    Description: '/opt/kubectl/kubectl 1.36.3; /opt/helm/helm 4.2.3',
   });
 });


### PR DESCRIPTION
Bumps HELM_VERSION from 4.2.2 to 4.2.3 and KUBECTL_VERSION from 1.36.2 to 1.36.3

Helm: https://github.com/helm/helm/releases/tag/v4.2.3
Kubectl: https://github.com/kubernetes/kubernetes/releases/tag/v1.36.3

[Helm support](https://helm.sh/docs/topics/version_skew/) : 4.2.x supports from 1.36.x - 1.33.x